### PR TITLE
:hammer: build: integrate `uv`

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Initialize venv and install packages
         run: |
+          pipx install uv
           just create-venv
+          source .venv/bin/activate
           just install
 
       - name: Test bilili API

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Initialize venv and install packages
         run: |
+          pipx install uv
           just create-venv
+          source .venv/bin/activate
           just install
 
       - name: e2e without subprocess

--- a/.github/workflows/lint-and-fmt.yml
+++ b/.github/workflows/lint-and-fmt.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Initialize venv and install packages
         run: |
+          pipx install uv
           just create-venv
+          source .venv/bin/activate
           just install
 
       - name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: build release distributions
         run: |
+          pipx install uv
           just create-venv
+          source .venv/bin/activate
           just install
           just build
 

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: docs/.vuepress/dist
-          external_repository: SigureMo/docs # 编译后直接转发到个人账户的 vercel-docs
+          external_repository: SigureMo/docs # 编译后直接转发到个人账户的 docs
           publish_branch: bilili
           force_orphan: true
           commit_message: ":rocket: deploy: "

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set positional-arguments
 
+PYTHON := ".venv/bin/python"
+
 create-venv:
   uv venv
 
@@ -10,14 +12,14 @@ install:
   uv pip install -e ".[dev]"
 
 run *ARGS:
-  python -m bilili {{ARGS}}
+  {{PYTHON}} -m bilili {{ARGS}}
 
 test:
   python -m pytest -m '(api or e2e) and not ci_only'
   just clean
 
 build:
-  python -m build
+  {{PYTHON}} -m build
 
 release version:
   @echo 'Tagging {{version}}...'
@@ -39,15 +41,15 @@ docs:
   cd docs/ && pnpm dev
 
 lint:
-  python -m ruff check .
+  {{PYTHON}} -m ruff check .
 
 fmt:
-  python -m ruff format .
+  {{PYTHON}} -m ruff format .
 
 ci-api-test:
-  python -m pytest -m "api and not ci_skip" --reruns 3 --reruns-delay 1
+  {{PYTHON}} -m pytest -m "api and not ci_skip" --reruns 3 --reruns-delay 1
   just clean
 
 ci-e2e-test:
-  python -m pytest -m "e2e and not ci_skip"
+  {{PYTHON}} -m pytest -m "e2e and not ci_skip"
   just clean

--- a/justfile
+++ b/justfile
@@ -1,22 +1,23 @@
 set positional-arguments
 
-PYTHON := ".venv/bin/python"
-
 create-venv:
-  python3 -m venv .venv
+  uv venv
+
+clean-venv:
+  rm -rf .venv
 
 install:
-  {{PYTHON}} -m pip install -e ".[dev]"
+  uv pip install -e ".[dev]"
 
 run *ARGS:
-  {{PYTHON}} -m bilili {{ARGS}}
+  python -m bilili {{ARGS}}
 
 test:
-  {{PYTHON}} -m pytest -m '(api or e2e) and not ci_only'
+  python -m pytest -m '(api or e2e) and not ci_only'
   just clean
 
 build:
-  {{PYTHON}} -m build
+  python -m build
 
 release version:
   @echo 'Tagging {{version}}...'
@@ -38,15 +39,15 @@ docs:
   cd docs/ && pnpm dev
 
 lint:
-  {{PYTHON}} -m ruff check .
+  python -m ruff check .
 
 fmt:
-  {{PYTHON}} -m ruff format .
+  python -m ruff format .
 
 ci-api-test:
-  {{PYTHON}} -m pytest -m "api and not ci_skip" --reruns 3 --reruns-delay 1
+  python -m pytest -m "api and not ci_skip" --reruns 3 --reruns-delay 1
   just clean
 
 ci-e2e-test:
-  {{PYTHON}} -m pytest -m "e2e and not ci_skip"
+  python -m pytest -m "e2e and not ci_skip"
   just clean


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 概述

<!-- 请在这里描述你的修改 -->

集成 [`uv`](https://github.com/astral-sh/uv)，跟随 uv 更新探索新一代项目管理方式

很久之前在 [yutto](https://github.com/yutto-dev/yutto) 等一些项目探索了基于 poetry 的项目管理方式，并提取出了模板 [python-lib-starter](https://github.com/ShigureLab/python-lib-starter)，但经过长期使用，发现 poetry 现存很多问题，其中最大的就是不支持 [PEP 621](https://peps.python.org/pep-0621/)（python-poetry/roadmap#3），这导致难以与其它 build backend 集成（比如 [maturin](https://github.com/PyO3/maturin)），因此我也一直在探索新的管理工具，但无论是 [pdm](https://github.com/pdm-project/pdm) 还是 [rye](https://github.com/mitsuhiko/rye)（其中 rye 最接近于理想态），都还不够

因为之前在 https://github.com/PaddlePaddle/PaddleSOT 探索过直接用 setuptools 配合 PEP 621 的极简项目管理方式，当时率先在 bilili 进行了测试，发现效果不错，而且可以方便地手动管理一切，事实上相比于 poetry 也差不了多少，因此感觉 poetry 的存在必要少了很多，虽然我也知道很多诸如 hatch、pdm、rye 之类的工具，但并没有一个真正合适的

从 [uv](https://github.com/astral-sh/uv) 的[发布](https://astral.sh/blog/uv)来看，roadmap 上的内容还是比较接近于理想态的，因此我会在 bilili 中先做实验，逐步探索新的项目管理方式，最终替换掉 [python-lib-starter](https://github.com/ShigureLab/python-lib-starter)

本 PR 的类型（至少选择一个）

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :art: style: 对代码语义无影响的格式修改（如去除无用空格、格式化等等修改）
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [x] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
